### PR TITLE
Removed Nomicoin Automation

### DIFF
--- a/overrides/scripts/coins.zs
+++ b/overrides/scripts/coins.zs
@@ -85,7 +85,7 @@ recipes.addShaped(<gregtech:ore_saltpeter_0> * 32, [[null, <nomilabs:nomicoin>, 
 recipes.addShaped(<gregtech:ore_graphite_0> * 32, [[null, null, <nomilabs:nomicoin>],[<nomilabs:nomicoin>, <nomilabs:nomicoin>, <nomilabs:nomicoin>], [null, null, <nomilabs:nomicoin>]]);
 recipes.addShaped(<gregtech:ore_powellite_0> * 32, [[null, <nomilabs:nomicoin>, null],[<nomilabs:nomicoin>, <nomilabs:nomicoin>, <nomilabs:nomicoin>], [<nomilabs:nomicoin>, null, null]]);
 
-recipes.addShaped(<gregtech:ore_oilsands_0> * 4, [[<nomilabs:nomicoin25>, null, null],[<nomilabs:nomicoin25>, <nomilabs:nomicoin25>, <nomilabs:nomicoin25>], [null, <nomilabs:nomicoin5>, null]]);
+recipes.addShaped(<gregtech:ore_oilsands_0>, [[<nomilabs:nomicoin25>, null, null],[<nomilabs:nomicoin25>, <nomilabs:nomicoin25>, <nomilabs:nomicoin25>], [null, <nomilabs:nomicoin25>, null]]);
 
 recipes.addShaped(<gregtech:ore_gold_0> * 32, [[<nomilabs:nomicoin25>, null, <nomilabs:nomicoin25>],[null, null, null], [null, null, null]]);
 recipes.addShaped(<gregtech:ore_emerald_0> * 32, [[<nomilabs:nomicoin25>, null, null],[null, null, null], [<nomilabs:nomicoin25>, null, null]]);

--- a/overrides/scripts/coins.zs
+++ b/overrides/scripts/coins.zs
@@ -85,7 +85,7 @@ recipes.addShaped(<gregtech:ore_saltpeter_0> * 32, [[null, <nomilabs:nomicoin>, 
 recipes.addShaped(<gregtech:ore_graphite_0> * 32, [[null, null, <nomilabs:nomicoin>],[<nomilabs:nomicoin>, <nomilabs:nomicoin>, <nomilabs:nomicoin>], [null, null, <nomilabs:nomicoin>]]);
 recipes.addShaped(<gregtech:ore_powellite_0> * 32, [[null, <nomilabs:nomicoin>, null],[<nomilabs:nomicoin>, <nomilabs:nomicoin>, <nomilabs:nomicoin>], [<nomilabs:nomicoin>, null, null]]);
 
-recipes.addShaped(<gregtech:ore_oilsands_0> * 16, [[<nomilabs:nomicoin5>, null, null],[<nomilabs:nomicoin5>, <nomilabs:nomicoin5>, <nomilabs:nomicoin5>], [null, <nomilabs:nomicoin5>, null]]);
+recipes.addShaped(<gregtech:ore_oilsands_0> * 4, [[<nomilabs:nomicoin25>, null, null],[<nomilabs:nomicoin25>, <nomilabs:nomicoin25>, <nomilabs:nomicoin25>], [null, <nomilabs:nomicoin5>, null]]);
 
 recipes.addShaped(<gregtech:ore_gold_0> * 32, [[<nomilabs:nomicoin25>, null, <nomilabs:nomicoin25>],[null, null, null], [null, null, null]]);
 recipes.addShaped(<gregtech:ore_emerald_0> * 32, [[<nomilabs:nomicoin25>, null, null],[null, null, null], [<nomilabs:nomicoin25>, null, null]]);

--- a/overrides/scripts/sussywussy.zs
+++ b/overrides/scripts/sussywussy.zs
@@ -83,12 +83,6 @@ solidifier.recipeBuilder()
     .duration(40).EUt(16).buildAndRegister();
 
 solidifier.recipeBuilder()
-    .fluidInputs(<liquid:lubricant> * 1000)
-    .notConsumable(<metaitem:shape.mold.bottle>)
-    .outputs(<contenttweaker:oil_barrel>)
-    .duration(40).EUt(16).buildAndRegister();
-
-solidifier.recipeBuilder()
     .fluidInputs(<liquid:natural_gas> * 1000)
     .notConsumable(<metaitem:shape.mold.bottle>)
     .outputs(<contenttweaker:oil_barrel>)


### PR DESCRIPTION
Nomicoins are able to be acquired automatically from turning in petrol barrels. This pr addresses two of them:

Fish to fish oil to lubricant to petrol barrel to nomicoins
Fish can be automated through DML, which the pack has blocked DML automation by making clay manual. Clay can be crafter through nomicoins, which reopens this line of automation.

Oil sands ore to Heavy oil to petrol barrel (either directly or via heavy fuel)
In LV, 1 Oil sands ore is equivalent to 1 nomipenny
In MV, 1 Oil sands ore is equivalent to 5 nomipennies (1 OS ore to 2kL Heavy Oil -> 5kL Heavy Fuel -> 5 nomipennies)
In HV, 1 Oil sands ore is equivalent to 8 nomipennies (1 OS ore to ~3.19 oilsands dust -> 3.19kL Heavy Oil -> 8kL HF -> 8 nomipennines)