### PR TITLE
Update RandomThings.zs

### DIFF
--- a/overrides/scripts/RandomThings.zs
+++ b/overrides/scripts/RandomThings.zs
@@ -32,7 +32,7 @@ recipes.addShaped(<randomthings:rainshield>, [
     [<minecraft:nether_brick>, <minecraft:nether_brick>, <minecraft:nether_brick>]
 ]);
 
-mods.jei.JEI.removeAndHide(<randomthings:block_destabilizer>);
+mods.jei.JEI.removeAndHide(<randomthings:blockdestabilizer>);
 mods.jei.JEI.removeAndHide(<randomthings:luminousblock:*>);
 mods.jei.JEI.removeAndHide(<randomthings:translucentluminousblock:*>);
 mods.jei.JEI.removeAndHide(<randomthings:customworkbench>);


### PR DESCRIPTION
Fixed named for block destabilizer to remove recipe randomthings:blockdestabilizer.

Two block destabilizers into next to each other, then powered cause a server crash.